### PR TITLE
Include clickable links in orb registry

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,4 +1,6 @@
-description: |-
-    Use Netsparker Enterprise to scan your web application for security vulnerabilities.
-    Full orb source code: https://github.com/netsparker/netsparker-orb
 version: 2.1
+description: |
+    Use Netsparker Enterprise to scan your web application for security vulnerabilities.
+display:
+    home_url: https://www.netsparker.com/
+    source_url: https://github.com/netsparker/netsparker-orb


### PR DESCRIPTION
New orb key allows for clickable links in the registry: https://circleci.com/docs/2.0/orb-author/#describing-your-orb
Example: https://circleci.com/orbs/registry/orb/circleci/serverless-framework

